### PR TITLE
Healthbar doesn't move when at the end of screen

### DIFF
--- a/Stickdom/level1.js
+++ b/Stickdom/level1.js
@@ -290,7 +290,6 @@ class level1 extends Phaser.Scene
                 this.bulletNum = 1;
             }
             this.key_Space._justUp = false;
-            console.log(this.healthBar.x);
         }
         //Moving left
         else if (this.key_Left.isDown)

--- a/Stickdom/level1.js
+++ b/Stickdom/level1.js
@@ -154,6 +154,8 @@ class level1 extends Phaser.Scene
         //Collider so healthbar doesn't go off screen
         this.physics.add.collider(this.healthBar, platforms);
         platforms.create(16,16,'blank');
+        platforms.create(2465, 16, 'blank');
+        
         //Health count
         var healthCount = 3;
         this.healthCount = 3;
@@ -272,8 +274,6 @@ class level1 extends Phaser.Scene
             {
                 velX = 200;
                 this.player.anims.play('shootRight');
-
-
             }
             if(this.bulletNum == 1)
             {
@@ -290,7 +290,7 @@ class level1 extends Phaser.Scene
                 this.bulletNum = 1;
             }
             this.key_Space._justUp = false;
-            // console.log(this.healthCount);
+            console.log(this.healthBar.x);
         }
         //Moving left
         else if (this.key_Left.isDown)
@@ -298,7 +298,7 @@ class level1 extends Phaser.Scene
             this.player.setVelocityX(-160);
             this.player.anims.play('left', true);
             this.direction = "left";
-            if(this.player.x>=395)
+            if(this.player.x>=395 && this.player.x < 2800)
             {
                 this.healthBar.setVelocityX(-160);
             }
@@ -310,7 +310,7 @@ class level1 extends Phaser.Scene
 
             this.player.anims.play('right', true);
             this.direction = "right";
-            if(this.player.x>=395 ) 
+            if(this.player.x>=395) 
             {
                 this.healthBar.setVelocityX(160);
             }


### PR DESCRIPTION
- Healthbar fixed at the end of the screen
- I'm confused on how to stop the healthbar from moving when the player bumps into a platform

Closes #12. 